### PR TITLE
Fix logic bugs and add performance optimizations in verification

### DIFF
--- a/lib/arbac_verifier/classes/reachability_verifier.rb
+++ b/lib/arbac_verifier/classes/reachability_verifier.rb
@@ -52,6 +52,8 @@ module ARBACVerifier
     def verify
       all_states = {}
       initial_state = @instance.user_to_role
+      return true if initial_state.any? { |ur| ur.role == @instance.goal }
+
       new_states = { initial_state => true }
       found = Concurrent::AtomicBoolean.new(false)
 
@@ -76,13 +78,14 @@ module ARBACVerifier
             Concurrent::Future.execute(executor: pool) do
               new_local_states = []
               perform_assignments(subject, object, new_local_states, all_states, current_state, found)
-              perform_revocations(subject, object, new_local_states, all_states, current_state)
+              perform_revocations(subject, object, new_local_states, all_states, current_state) unless found.true?
               new_local_states
             end
           end
         end
 
         futures.each do |future|
+          break if found.true?
           future.value.each { |state| new_states[state] = true }
         end
         break if found.true?
@@ -98,7 +101,7 @@ module ARBACVerifier
       params(
         subject: String,
         object: String,
-        new_states: T::Array[Symbol],
+        new_states: T::Array[T::Set[UserRole]],
         all_states: T::Hash[T::Set[UserRole], T::Boolean],
         current_state: T::Set[UserRole],
         found: Concurrent::AtomicBoolean
@@ -106,6 +109,7 @@ module ARBACVerifier
     end
     private def perform_assignments(subject, object, new_states, all_states, current_state, found)
       @instance.can_assign_rules.each do |rule|
+        break if found.true?
         if rule.can_apply?(current_state, subject, object)
           new_state = rule.apply(current_state, object)
           if new_state.any? { |ur| ur.role == @instance.goal }
@@ -121,7 +125,7 @@ module ARBACVerifier
       params(
         subject: String,
         object: String,
-        new_states: T::Array[Symbol],
+        new_states: T::Array[T::Set[UserRole]],
         all_states: T::Hash[T::Set[UserRole], T::Boolean],
         current_state: T::Set[UserRole]
       ).void

--- a/lib/arbac_verifier/classes/rules/can_assign.rb
+++ b/lib/arbac_verifier/classes/rules/can_assign.rb
@@ -38,7 +38,7 @@ module ARBACVerifier
         assignee: String).returns T::Boolean
       end
       def can_apply?(state, assigner, assignee)
-        assigner_has_rights = state.to_a.any?{ |ur| ur.user == assigner and ur.role == @user_role}
+        assigner_has_rights = state.any?{ |ur| ur.user == assigner and ur.role == @user_role}
         assignee_roles = state.select { |ur| ur.user == assignee}.map { |ar| ar.role }.to_set
         assigner_has_rights and
           positive_precondition_roles.subset? assignee_roles and

--- a/lib/arbac_verifier/classes/rules/can_revoke.rb
+++ b/lib/arbac_verifier/classes/rules/can_revoke.rb
@@ -25,8 +25,8 @@ module ARBACVerifier
         revokee: String).returns T::Boolean
       end
       def can_apply?(state, revoker, revokee)
-        assigner_has_rights = state.to_a.any?{ |ur| ur.user == revoker and ur.role == @user_role}
-        assignee_has_revoking_role = state.to_a.any?{ |ur| ur.user == revokee and ur.role == target_role}
+        assigner_has_rights = state.any?{ |ur| ur.user == revoker and ur.role == @user_role}
+        assignee_has_revoking_role = state.any?{ |ur| ur.user == revokee and ur.role == target_role}
         assigner_has_rights and assignee_has_revoking_role
       end
 

--- a/lib/arbac_verifier/modules/utils.rb
+++ b/lib/arbac_verifier/modules/utils.rb
@@ -36,7 +36,7 @@ module ARBACVerifier
         reachable_roles = evolving_roles_set.dup
         policy.can_assign_rules.each do |car|
           precondition_roles = car.positive_precondition_roles | [car.user_role]
-          if precondition_roles.proper_subset?(reachable_roles)
+          if precondition_roles.subset?(reachable_roles)
             evolving_roles_set << car.target_role
           end
         end


### PR DESCRIPTION
Bug fixes:
- Fix overaproximate_reachable_roles using proper_subset? instead of subset?, which caused forward slicing to incorrectly eliminate reachable roles and could produce false 'unreachable' results
- Check initial state for goal role before starting BFS; previously if a user already held the goal role the verifier would return false instead of true
- Fix Sorbet type annotations: new_states params typed as T::Array[Symbol] instead of T::Array[T::Set[UserRole]]

Performance optimizations:
- Remove unnecessary .to_a conversions in can_apply? (Set already supports any?)
- Add early break inside futures.each when goal is already found to avoid waiting for and processing remaining futures unnecessarily
- Skip perform_revocations within a future when goal is already found
- Add early break inside perform_assignments rule loop when found is true

https://claude.ai/code/session_01EYqjwJUDUuJxdwBgPzjaCy